### PR TITLE
Fix check_mount script when / isn't first line of /proc/mounts

### DIFF
--- a/check_mount
+++ b/check_mount
@@ -11,7 +11,7 @@ STRING=`head -n8 /dev/urandom| tr -dc 'a-zA-Z' | fold -w 25 | head -n1`
 
 if [ $# -eq "2" ]; then
 
-        CHECK=`cat /proc/mounts | grep $1`
+        CHECK=`awk '$2 == var' var=$1 /proc/mounts`
         MOUNTPOINT=`echo $CHECK | cut -d' ' -f2`
         MOUNTTYPE=`echo $CHECK | cut -d' ' -f3`
 


### PR DESCRIPTION
Bug: `grep $1` matches everything from /proc/mounts, that is the specific field that we want to match and everything else. So in the case of $1 == "/", it was matching every line from /proc/mounts, but the check only works if the / mount is the first line, which is not happening in xenial.
Fix: match the wanted mount point against the specific field of /proc/mounts output