### PR TITLE
skyscrapers/puppet#3148: Fixing the unicorn check scripts.

### DIFF
--- a/check_unicorn
+++ b/check_unicorn
@@ -12,14 +12,12 @@ OK_STATE=0
 WARNING_STATE=1
 CRITICAL_STATE=2
 UNKNOWN_STATE=3
-EXPECTED_ARGS=1
-E_BADARGS=65
+EXPECTED_ARGS=2
 
 if [ $# -ne $EXPECTED_ARGS ]
 then
     echo "Usage: `basename $0` [number of workers minimum] [number of workers maximum]"
     exit ${UNKNOWN_STATE}
-    exit $E_BADARGS
 fi
 
 check_master=`ps awx | egrep "(unicorn|unicorn_rails) master" | grep -v grep`

--- a/check_unicorn
+++ b/check_unicorn
@@ -37,6 +37,9 @@ if [[ "$count_master" -eq 1 ]]; then
                 elif [[ "$count_workers" -lt $1 ]]; then
                         echo "CRITICAL - only $count_workers unicorn workers are running !"
                         exit ${CRITICAL_STATE}
+                else
+                        echo "OK - $count_workers unicorn workers running"
+                        exit ${OK_STATE}
                 fi
         fi
 elif [[ "$count_master" -gt 1 ]]; then

--- a/check_unicorn_memory
+++ b/check_unicorn_memory
@@ -19,7 +19,7 @@ pid_file="`find /var/www -name *.pid`"
 pids_folder="`dirname $pid_file`"
 
 if [[ "$#" -ne "$EXPECTED_ARGS" || "$1" != '-w' || "$3" != '-c' ]]; then
-    echo "Usage: `basename $0` [-w] worker_memory_MiB [-c] worker_memory_MiB"
+    echo "Usage: `basename $0` -w worker_memory_MiB -c worker_memory_MiB"
     exit ${UNKNOWN_STATE}
 elif [[ "$4" -lt "$2" ]]; then
     echo "UNKNOWN - Critical value < Warning value. Please verify parameters."

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=1.3.32
+VERSION=1.3.33
 
 rm -rf *.deb
 


### PR DESCRIPTION
* Fixed the number of args in the `check_unicorn` scripts.
* Updated the usage info to indicate `-w` and `-c` are required rather than optional arguments.