### PR TITLE
Update check_rabbitmq

### DIFF
--- a/check_rabbitmq
+++ b/check_rabbitmq
@@ -39,6 +39,7 @@ class RabbitCmdWrapper(object):
         #remove text fluff
         if "Listing connections ..." in results: results.remove("Listing connections ...")
         if "Listing queues ..." in results: results.remove("Listing queues ...")
+        if "name\tmessages" in results: results.remove("name\tmessages")
         return_data = []
         for row in results:
             return_data.append(row.split('\t'))


### PR DESCRIPTION
Remove new header in the response: 'name\tmessages'

## Description
check_rabbitmq for queue count fails because of a new header in the response: 'name\tmessages'

## Related Issue
https://github.com/skyscrapers/monitoring-plugins/issues/22

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
